### PR TITLE
Intermediate custom tactics.

### DIFF
--- a/src/coq/logicutils/contexts/envutils.mli
+++ b/src/coq/logicutils/contexts/envutils.mli
@@ -8,6 +8,7 @@ open Constr
 open Names
 open Contextutils
 open Evd
+open Stateutils
 
 (* Look up all indexes from a list in an environment *)
 val lookup_rels : int list -> env -> CRD.t list
@@ -54,3 +55,8 @@ val get_pushed_names : env -> Id.Set.t
   
 (* If the given name is anonymous, generate a fresh one. *)
 val fresh_name : env -> Name.t -> Id.t
+
+                                    
+(* Returns true if the relative bindings in each environment
+   are syntactically equal. *)
+val compare_envs : env -> env -> evar_map -> bool state

--- a/src/coq/logicutils/hofs/hofs.ml
+++ b/src/coq/logicutils/hofs/hofs.ml
@@ -22,6 +22,8 @@ type ('a, 'b) list_transformer = 'a -> 'b -> 'b list
 type ('a, 'b) transformer_with_env = env -> evar_map -> 'a -> 'b -> evar_map * 'b
 type 'b unit_transformer_with_env = env -> evar_map -> 'b -> evar_map * 'b
 type ('a, 'b) list_transformer_with_env = env -> evar_map -> 'a -> 'b -> evar_map * 'b list
+type ('a, 'b) transformer_with_env_types = env -> evar_map -> 'a -> types -> evar_map * 'b
+type ('a, 'b) list_transformer_with_env_types = env -> evar_map -> 'a -> types -> (evar_map * 'b) list
 
 (* Updating arguments *)
 type 'a updater = 'a -> 'a

--- a/src/coq/logicutils/hofs/hofs.ml
+++ b/src/coq/logicutils/hofs/hofs.ml
@@ -485,10 +485,10 @@ let rec map_subterms_env_if_combs p f d env sigma a trm =
 let rec map_term_env_if_list p f d env sigma a trm =
   let map_rec = map_term_env_if_list p f d in
   let sigma_t, p_holds = p env sigma a trm in
-  if p_holds then
-    [f env sigma_t a trm]
-  else
-    match kind trm with
+  let new_subterms = if p_holds
+                     then [f env sigma_t a trm]
+                     else [] in
+  let rest = match kind trm with
     | Cast (c, k, t) ->
        let c' = map_rec env sigma a c in
        let t' = map_rec env sigma a t in
@@ -526,7 +526,8 @@ let rec map_term_env_if_list p f d env sigma a trm =
     | Proj (pr, c) ->
        map_rec env sigma a c
     | _ ->
-       []
+       [] in
+  List.append new_subterms rest
 
 (*
  * Map a function over subterms of a term in an environment

--- a/src/coq/logicutils/hofs/hofs.mli
+++ b/src/coq/logicutils/hofs/hofs.mli
@@ -18,6 +18,9 @@ type ('a, 'b) list_transformer = 'a -> 'b -> 'b list
 type ('a, 'b) transformer_with_env = env -> evar_map -> 'a -> 'b -> evar_map * 'b
 type 'b unit_transformer_with_env = env -> evar_map -> 'b -> evar_map * 'b
 type ('a, 'b) list_transformer_with_env = env -> evar_map -> 'a -> 'b -> evar_map * 'b list
+type ('a, 'b) transformer_with_env_types = env -> evar_map -> 'a -> types -> evar_map * 'b
+type ('a, 'b) list_transformer_with_env_types = env -> evar_map -> 'a -> types -> (evar_map * 'b) list
+                                             
 
 (* Updating arguments *)
 type 'a updater = 'a -> 'a
@@ -162,6 +165,14 @@ val map_unit_env_if_lazy : types conditional_unit_mapper_with_env
  * Like map_term_env_if, but don't recurse into lambda arguments
  *)
 val map_term_env_if_shallow : ('a, types) conditional_mapper_with_env
+
+(*
+ * Like map_term_env_if, but return a list of matched results
+ *)
+val map_term_env_if_list : ('a, types) pred_with_env ->
+                           ('a, env * types) transformer_with_env_types ->
+                           'a updater ->
+                           ('a, env * types) list_transformer_with_env_types
 
 (*
  * Like map_term_env_if, but in the empty environment

--- a/src/coq/logicutils/hofs/typehofs.ml
+++ b/src/coq/logicutils/hofs/typehofs.ml
@@ -17,3 +17,11 @@ let on_red_type_default f env sigma trm =
 
 let on_type f env sigma trm =
   on_red_type do_not_reduce f env sigma trm
+
+let subterms_with_type env sigma =
+  Hofs.map_term_env_if_list
+    Checking.has_type
+    (fun env sigma typ trm -> sigma, (env, trm))
+    Debruijn.shift
+    env
+    sigma

--- a/src/coq/logicutils/hofs/typehofs.mli
+++ b/src/coq/logicutils/hofs/typehofs.mli
@@ -35,3 +35,11 @@ val on_red_type_default :
   evar_map ->
   types ->
   'a
+
+(* Returns a list of all subterms of a term with a given type. *)
+val subterms_with_type :
+  env ->
+  evar_map ->
+  types ->
+  constr ->
+  (evar_map * (env * constr)) list

--- a/src/utilities/utilities.ml
+++ b/src/utilities/utilities.ml
@@ -172,6 +172,34 @@ let rec split_at (n : int) (l : 'a list) : (('a list) * ('a list)) =
     | [] ->
        ([], [])
 
+(* Try to get the second element of a list, defaulting
+   to the first, raising NotFound if empty. *)
+let list_snd (xs : 'a list) : 'a =
+  match xs with
+  | x :: y :: _ -> y
+  | xs -> List.hd xs
+  
+(* Compare whether all elements of two lists of equal length are equal. *)
+let rec list_eq (cmp : 'a -> 'a -> bool) xs ys : bool =
+  match xs, ys with
+  | [], [] -> true
+  | x :: xs', y :: ys' -> cmp x y && list_eq cmp xs' ys'
+  | _, _ -> false
+          
+(* Compare if all elements of a single list are equal. *)
+let all_eq (cmp : 'a -> 'a -> bool) xs : bool =
+  match xs with
+  | [] -> true
+  | x :: xs' -> List.for_all (fun y -> cmp x y) xs'
+ 
+(* Count length of shared prefix between lists. *)
+let rec count_shared_prefix (cmp : 'a -> 'a -> bool) xs ys  : int =
+  match xs, ys with
+  | x :: xs', y :: ys' ->
+     if cmp x y then 1 + count_shared_prefix cmp xs' ys' else 0
+  | _, _ -> 0
+
+      
 (* --- Tuples --- *)
              
 (* Map f over a tuple *)

--- a/src/utilities/utilities.mli
+++ b/src/utilities/utilities.mli
@@ -104,6 +104,27 @@ val from_one_to : int -> int list
  *)
 val split_at : int -> 'a list -> (('a list) * ('a list))
 
+(* 
+ * Try to get the second element of a list, defaulting
+ * to the first, raising NotFound if empty. 
+ *)
+val list_snd : 'a list -> 'a
+  
+(* 
+ *Compare whether all elements of two lists of equal length are equal. 
+ *)
+val list_eq : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+          
+(*
+ * Compare if all elements of a single list are equal.
+ *)
+val all_eq : ('a -> 'a -> bool) -> 'a list ->  bool
+
+(* 
+ * Count length of shared prefix between lists.
+ *)
+val count_shared_prefix : ('a -> 'a -> bool) -> 'a list -> 'a list -> int
+  
 (* --- Tuples --- *)
 
 val map_tuple : ('a -> 'b) -> ('a * 'a) -> ('b * 'b)


### PR DESCRIPTION
Decompiler supports goal solving, goal transforming, and context transforming argumentless custom tactics.

Example (using StructTact):

`Decompile th with "solve_by_inversion" "break_exists".`

can decompile:

```
Theorem th : forall x : nat, x = 0 -> (exists y, S y = x) -> False.
Proof.
intro x.
induction x as [ |x0 IHx0].
- intros H0 H1.
  break_exists.
  solve_by_inversion.
- intros IHx H.
  solve_by_inversion.
Qed.
```


